### PR TITLE
add publicPath option for vue build

### DIFF
--- a/src/VueCliAndCore/client-app/vue.config.js
+++ b/src/VueCliAndCore/client-app/vue.config.js
@@ -1,5 +1,6 @@
 ﻿// vue.config.js
 module.exports = {
   outputDir: "../wwwroot/client-app/",
+  publicPath: "/client-app/",
   filenameHashing: false
 }


### PR DESCRIPTION
Without public path vue considers app is deployed and resources are located in root of domain.